### PR TITLE
Update Program.cs

### DIFF
--- a/EchoVRQuestApkPatcher/Program.cs
+++ b/EchoVRQuestApkPatcher/Program.cs
@@ -141,7 +141,7 @@ static class Program
         Console.WriteLine("Extracting files...");
         ZipFile.ExtractToDirectory(args[0], extractedApkDir);
         var extractedLocalPath = Path.Join(extractedApkDir, "assets", "_local");
-        var extractedPnsRadOvrPath = Path.Join(extractedApkDir, @"lib\arm64-v8a\libpnsovr.so");
+        var extractedPnsRadOvrPath = Path.Join(extractedApkDir, @"lib", "arm64-v8a", "libpnsovr.so");
 
         Console.WriteLine("Copying config.json...");
         Directory.CreateDirectory(extractedLocalPath); // No need to check for existence, as the hash will capture that


### PR DESCRIPTION
Use Path.join instead of hardcoded `\` so this works on mac / linux, got this working locally by installing .Net 7 on my mac and running `dotnet build && dotnet run -- path/to/echo/apk/r15_goldmaster_store.apk` <--- this path should also have config.json in it